### PR TITLE
Merge StateParser class and drop support PHP before 5.3

### DIFF
--- a/XML/HTMLSax3.php
+++ b/XML/HTMLSax3.php
@@ -22,13 +22,13 @@
 // $Id: HTMLSax3.php,v 1.2 2007/10/29 21:41:34 hfuecks Exp $
 //
 /**
-* Main parser components
-* @package XML_HTMLSax3
-* @version $Id: HTMLSax3.php,v 1.2 2007/10/29 21:41:34 hfuecks Exp $
-*/
+ * Main parser components
+ * @package XML_HTMLSax3
+ * @version $Id: HTMLSax3.php,v 1.2 2007/10/29 21:41:34 hfuecks Exp $
+ */
 /**
-* Required classes
-*/
+ * Required classes
+ */
 if (!defined('XML_HTMLSAX3')) {
     define('XML_HTMLSAX3', 'XML/');
 }
@@ -36,126 +36,126 @@ require_once(XML_HTMLSAX3 . 'HTMLSax3/States.php');
 require_once(XML_HTMLSAX3 . 'HTMLSax3/Decorators.php');
 
 /**
-* Base State Parser
-* @package XML_HTMLSax3
-* @access protected
-*/
+ * Base State Parser
+ * @package XML_HTMLSax3
+ * @access protected
+ */
 class XML_HTMLSax3_StateParser
 {
     /**
-    * Instance of user front end class to be passed to callbacks
-    * @var XML_HTMLSax3
-    * @access private
-    */
+     * Instance of user front end class to be passed to callbacks
+     * @var XML_HTMLSax3
+     * @access private
+     */
     var $htmlsax;
     /**
-    * User defined object for handling elements
-    * @var object
-    * @access private
-    */
+     * User defined object for handling elements
+     * @var object
+     * @access private
+     */
     var $handler_object_element;
     /**
-    * User defined open tag handler method
-    * @var string
-    * @access private
-    */
+     * User defined open tag handler method
+     * @var string
+     * @access private
+     */
     var $handler_method_opening;
     /**
-    * User defined close tag handler method
-    * @var string
-    * @access private
-    */
+     * User defined close tag handler method
+     * @var string
+     * @access private
+     */
     var $handler_method_closing;
     /**
-    * User defined object for handling data in elements
-    * @var object
-    * @access private
-    */
+     * User defined object for handling data in elements
+     * @var object
+     * @access private
+     */
     var $handler_object_data;
     /**
-    * User defined data handler method
-    * @var string
-    * @access private
-    */
+     * User defined data handler method
+     * @var string
+     * @access private
+     */
     var $handler_method_data;
     /**
-    * User defined object for handling processing instructions
-    * @var object
-    * @access private
-    */
+     * User defined object for handling processing instructions
+     * @var object
+     * @access private
+     */
     var $handler_object_pi;
     /**
-    * User defined processing instruction handler method
-    * @var string
-    * @access private
-    */
+     * User defined processing instruction handler method
+     * @var string
+     * @access private
+     */
     var $handler_method_pi;
     /**
-    * User defined object for handling JSP/ASP tags
-    * @var object
-    * @access private
-    */
+     * User defined object for handling JSP/ASP tags
+     * @var object
+     * @access private
+     */
     var $handler_object_jasp;
     /**
-    * User defined JSP/ASP handler method
-    * @var string
-    * @access private
-    */
+     * User defined JSP/ASP handler method
+     * @var string
+     * @access private
+     */
     var $handler_method_jasp;
     /**
-    * User defined object for handling XML escapes
-    * @var object
-    * @access private
-    */
+     * User defined object for handling XML escapes
+     * @var object
+     * @access private
+     */
     var $handler_object_escape;
     /**
-    * User defined XML escape handler method
-    * @var string
-    * @access private
-    */
+     * User defined XML escape handler method
+     * @var string
+     * @access private
+     */
     var $handler_method_escape;
     /**
-    * User defined handler object or NullHandler
-    * @var object
-    * @access private
-    */
+     * User defined handler object or NullHandler
+     * @var object
+     * @access private
+     */
     var $handler_default;
     /**
-    * Parser options determining parsing behavior
-    * @var array
-    * @access private
-    */
+     * Parser options determining parsing behavior
+     * @var array
+     * @access private
+     */
     var $parser_options = array();
     /**
-    * XML document being parsed
-    * @var string
-    * @access private
-    */
+     * XML document being parsed
+     * @var string
+     * @access private
+     */
     var $rawtext;
     /**
-    * Position in XML document relative to start (0)
-    * @var int
-    * @access private
-    */
+     * Position in XML document relative to start (0)
+     * @var int
+     * @access private
+     */
     var $position;
     /**
-    * Length of the XML document in characters
-    * @var int
-    * @access private
-    */
+     * Length of the XML document in characters
+     * @var int
+     * @access private
+     */
     var $length;
     /**
-    * Array of state objects
-    * @var array
-    * @access private
-    */
+     * Array of state objects
+     * @var array
+     * @access private
+     */
     var $State = array();
 
     /**
-    * Constructs XML_HTMLSax3_StateParser setting up states and defining available parser options
-    * @var XML_HTMLSax3 $htmlsax instance of user front end class
-    * @access protected
-    */
+     * Constructs XML_HTMLSax3_StateParser setting up states and defining available parser options
+     * @param XML_HTMLSax3 $htmlsax Instance of user front end class
+     * @access protected
+     */
     public function __construct($htmlsax)
     {
         $this->htmlsax = $htmlsax;
@@ -164,42 +164,46 @@ class XML_HTMLSax3_StateParser
     }
 
     /**
-    * Moves the position back one character
-    * @access protected
-    * @return void
-    */
-    function unscanCharacter() {
+     * Moves the position back one character
+     * @access protected
+     * @return void
+     */
+    function unscanCharacter()
+    {
         $this->position -= 1;
     }
 
     /**
-    * Moves the position forward one character
-    * @access protected
-    * @return void
-    */
-    function ignoreCharacter() {
+     * Moves the position forward one character
+     * @access protected
+     * @return void
+     */
+    function ignoreCharacter()
+    {
         $this->position += 1;
     }
 
     /**
-    * Returns the next character from the XML document or void if at end
-    * @access protected
-    * @return mixed
-    */
-    function scanCharacter() {
+     * Returns the next character from the XML document or void if at end
+     * @access protected
+     * @return mixed
+     */
+    function scanCharacter()
+    {
         if ($this->position < $this->length) {
             return $this->rawtext[$this->position++];
         }
     }
 
     /**
-    * Returns a string from the current position to the next occurance
-    * of the supplied string
-    * @param string string to search until
-    * @access protected
-    * @return string
-    */
-    function scanUntilString($string) {
+     * Returns a string from the current position to the next occurance
+     * of the supplied string
+     * @param string $string String to search until
+     * @access protected
+     * @return string
+     */
+    function scanUntilString($string)
+    {
         $start = $this->position;
         $this->position = strpos($this->rawtext, $string, $start);
         if ($this->position === FALSE) {
@@ -209,12 +213,12 @@ class XML_HTMLSax3_StateParser
     }
 
     /**
-    * Returns a string from the current position until the first instance of
-    * one of the characters in the supplied string argument
-    * @param string string to search until
-    * @access protected
-    * @return string
-    */
+     * Returns a string from the current position until the first instance of
+     * one of the characters in the supplied string argument
+     * @param string $string String to search until
+     * @access protected
+     * @return string
+     */
     function scanUntilCharacters($string)
     {
         $startpos = $this->position;
@@ -224,23 +228,24 @@ class XML_HTMLSax3_StateParser
     }
 
     /**
-    * Moves the position forward past any whitespace characters
-    * @access protected
-    * @return void
-    */
+     * Moves the position forward past any whitespace characters
+     * @access protected
+     * @return void
+     */
     function ignoreWhitespace()
     {
         $this->position += strspn($this->rawtext, " \n\r\t", $this->position);
     }
 
     /**
-    * Begins the parsing operation, setting up any decorators, depending on
-    * parse options invoking _parse() to execute parsing
-    * @param string XML document to parse
-    * @access protected
-    * @return void
-    */
-    function parse($data) {
+     * Begins the parsing operation, setting up any decorators, depending on
+     * parse options invoking _parse() to execute parsing
+     * @param string $data XML document to parse
+     * @access protected
+     * @return void
+     */
+    function parse($data)
+    {
         if ($this->parser_options['XML_OPTION_TRIM_DATA_NODES']==1) {
             $decorator = new XML_HTMLSax3_Trim(
                 $this->handler_object_data,
@@ -300,12 +305,11 @@ class XML_HTMLSax3_StateParser
     }
 
     /**
-    * Performs the parsing itself, delegating calls to a specific parser
-    * state
-    * @param constant state object to parse with
-    * @access protected
-    * @return void
-    */
+     * Performs the parsing itself, delegating calls to a specific parser state
+     * @param int $state State object to parse with
+     * @access protected
+     * @return void
+     */
     function _parse($state = XML_HTMLSAX3_STATE_START) {
         do {
             $state = $this->State[$state]->parse($this);
@@ -347,49 +351,50 @@ class XML_HTMLSax3_StateParser
 }
 
 /**
-* Default NullHandler for methods which were not set by user
-* @package XML_HTMLSax3
-* @access protected
-*/
-class XML_HTMLSax3_NullHandler {
+ * Default NullHandler for methods which were not set by user
+ * @package XML_HTMLSax3
+ * @access protected
+ */
+class XML_HTMLSax3_NullHandler
+{
     /**
-    * Generic handler method which does nothing
-    * @access protected
-    * @return void
-    */
+     * Generic handler method which does nothing
+     * @access protected
+     * @return void
+     */
     function DoNothing() {
     }
 }
 
 /**
-* User interface class. All user calls should only be made to this class
-* @package XML_HTMLSax3
-* @access public
-*/
+ * User interface class. All user calls should only be made to this class
+ * @package XML_HTMLSax3
+ * @access public
+ */
 class XML_HTMLSax3 {
     /**
-    * Instance of concrete subclass of XML_HTMLSax3_StateParser
-    * @var XML_HTMLSax3_StateParser
-    * @access private
-    */
+     * Instance of concrete subclass of XML_HTMLSax3_StateParser
+     * @var XML_HTMLSax3_StateParser
+     * @access private
+     */
     var $state_parser;
 
     /**
-    * Constructs XML_HTMLSax3 selecting concrete StateParser subclass
-    * depending on PHP version being used as well as setting the default
-    * NullHandler for all callbacks<br />
-    * <b>Example:</b>
-    * <pre>
-    * $myHandler = & new MyHandler();
-    * $parser = new XML_HTMLSax3();
-    * $parser->set_object($myHandler);
-    * $parser->set_option('XML_OPTION_CASE_FOLDING');
-    * $parser->set_element_handler('myOpenHandler','myCloseHandler');
-    * $parser->set_data_handler('myDataHandler');
-    * $parser->parser($xml);
-    * </pre>
-    * @access public
-    */
+     * Constructs XML_HTMLSax3 selecting concrete StateParser subclass
+     * depending on PHP version being used as well as setting the default
+     * NullHandler for all callbacks<br />
+     * <b>Example:</b>
+     * <pre>
+     * $myHandler = & new MyHandler();
+     * $parser = new XML_HTMLSax3();
+     * $parser->set_object($myHandler);
+     * $parser->set_option('XML_OPTION_CASE_FOLDING');
+     * $parser->set_element_handler('myOpenHandler','myCloseHandler');
+     * $parser->set_data_handler('myDataHandler');
+     * $parser->parser($xml);
+     * </pre>
+     * @access public
+     */
     public function __construct()
     {
         $this->state_parser = new XML_HTMLSax3_StateParser($this);
@@ -403,13 +408,14 @@ class XML_HTMLSax3 {
     }
 
     /**
-    * Sets the user defined handler object. Returns a PEAR Error
-    * if supplied argument is not an object.
-    * @param object handler object containing SAX callback methods
-    * @access public
-    * @return mixed
-    */
-    function set_object($object) {
+     * Sets the user defined handler object. Returns a PEAR Error
+     * if supplied argument is not an object.
+     * @param object $object Handler object containing SAX callback methods
+     * @access public
+     * @return mixed
+     */
+    function set_object($object)
+    {
         if ( is_object($object) ) {
             $this->state_parser->handler_default = $object;
             return true;
@@ -421,33 +427,34 @@ class XML_HTMLSax3 {
     }
 
     /**
-    * Sets a parser option. By default all options are switched off.
-    * Returns a PEAR Error if option is invalid<br />
-    * <b>Available options:</b>
-    * <ul>
-    * <li>XML_OPTION_TRIM_DATA_NODES: trim whitespace off the beginning
-    * and end of data passed to the data handler</li>
-    * <li>XML_OPTION_LINEFEED_BREAK: linefeeds result in additional data
-    * handler calls</li>
-    * <li>XML_OPTION_TAB_BREAK: tabs result in additional data handler
-    * calls</li>
-    * <li>XML_OPTION_ENTITIES_UNPARSED: XML entities are returned as
-    * seperate data handler calls in unparsed form</li>
-    * <li>XML_OPTION_ENTITIES_PARSED: (PHP 4.3.0+ only) XML entities are
-    * returned as seperate data handler calls and are parsed with
-    * PHP's html_entity_decode() function</li>
-    * <li>XML_OPTION_STRIP_ESCAPES: strips out the -- -- comment markers
-    * or CDATA markup inside an XML escape, if found.</li>
-    * </ul>
-    * To get HTMLSax to behave in the same way as the native PHP SAX parser,
-    * using it's default state, you need to switch on XML_OPTION_LINEFEED_BREAK,
-    * XML_OPTION_ENTITIES_PARSED and XML_OPTION_CASE_FOLDING
-    * @param string name of parser option
-    * @param int (optional) 1 to switch on, 0 for off
-    * @access public
-    * @return boolean
-    */
-    function set_option($name, $value=1) {
+     * Sets a parser option. By default all options are switched off.
+     * Returns a PEAR Error if option is invalid<br />
+     * <b>Available options:</b>
+     * <ul>
+     * <li>XML_OPTION_TRIM_DATA_NODES: trim whitespace off the beginning
+     * and end of data passed to the data handler</li>
+     * <li>XML_OPTION_LINEFEED_BREAK: linefeeds result in additional data
+     * handler calls</li>
+     * <li>XML_OPTION_TAB_BREAK: tabs result in additional data handler
+     * calls</li>
+     * <li>XML_OPTION_ENTITIES_UNPARSED: XML entities are returned as
+     * seperate data handler calls in unparsed form</li>
+     * <li>XML_OPTION_ENTITIES_PARSED: (PHP 4.3.0+ only) XML entities are
+     * returned as seperate data handler calls and are parsed with
+     * PHP's html_entity_decode() function</li>
+     * <li>XML_OPTION_STRIP_ESCAPES: strips out the -- -- comment markers
+     * or CDATA markup inside an XML escape, if found.</li>
+     * </ul>
+     * To get HTMLSax to behave in the same way as the native PHP SAX parser,
+     * using it's default state, you need to switch on XML_OPTION_LINEFEED_BREAK,
+     * XML_OPTION_ENTITIES_PARSED and XML_OPTION_CASE_FOLDING
+     * @param string $name Name of parser option
+     * @param int $value (optional) 1 to switch on, 0 for off
+     * @access public
+     * @return boolean
+     */
+    function set_option($name, $value = 1)
+    {
         if ( array_key_exists($name,$this->state_parser->parser_options) ) {
             $this->state_parser->parser_options[$name] = $value;
             return true;
@@ -458,135 +465,141 @@ class XML_HTMLSax3 {
     }
 
     /**
-    * Sets the data handler method which deals with the contents of XML
-    * elements.<br />
-    * The handler method must accept two arguments, the first being an
-    * instance of XML_HTMLSax3 and the second being the contents of an
-    * XML element e.g.
-    * <pre>
-    * function myDataHander(& $parser,$data){}
-    * </pre>
-    * @param string name of method
-    * @access public
-    * @return void
-    * @see set_object
-    */
-    function set_data_handler($data_method) {
+     * Sets the data handler method which deals with the contents of XML elements.
+     * The handler method must accept two arguments, the first being an
+     * instance of XML_HTMLSax3 and the second being the contents of an
+     * XML element e.g.
+     * <pre>
+     * function myDataHander(& $parser,$data){}
+     * </pre>
+     * @param string $data_method Name of method
+     * @access public
+     * @return void
+     * @see set_object()
+     */
+    function set_data_handler($data_method)
+    {
         $this->state_parser->handler_object_data = $this->state_parser->handler_default;
         $this->state_parser->handler_method_data = $data_method;
     }
 
     /**
-    * Sets the open and close tag handlers
-    * <br />The open handler method must accept three arguments; the parser,
-    * the tag name and an array of attributes e.g.
-    * <pre>
-    * function myOpenHander(& $parser,$tagname,$attrs=array()){}
-    * </pre>
-    * The close handler method must accept two arguments; the parser and
-    * the tag name e.g.
-    * <pre>
-    * function myCloseHander(& $parser,$tagname){}
-    * </pre>
-    * @param string name of open method
-    * @param string name of close method
-    * @access public
-    * @return void
-    * @see set_object
-    */
-    function set_element_handler($opening_method, $closing_method) {
+     * Sets the open and close tag handlers
+     * The open handler method must accept three arguments; the parser,
+     * the tag name and an array of attributes e.g.
+     * <pre>
+     * function myOpenHander(& $parser,$tagname,$attrs=array()){}
+     * </pre>
+     * The close handler method must accept two arguments; the parser and
+     * the tag name e.g.
+     * <pre>
+     * function myCloseHander(& $parser,$tagname){}
+     * </pre>
+     * @param string $opening_method Name of open method
+     * @param string $closing_method Name of close method
+     * @access public
+     * @return void
+     * @see set_object()
+     */
+    function set_element_handler($opening_method, $closing_method)
+    {
         $this->state_parser->handler_object_element = $this->state_parser->handler_default;
         $this->state_parser->handler_method_opening = $opening_method;
         $this->state_parser->handler_method_closing = $closing_method;
     }
 
     /**
-    * Sets the processing instruction handler method e.g. for PHP open
-    * and close tags<br />
-    * The handler method must accept three arguments; the parser, the
-    * PI target and data inside the PI
-    * <pre>
-    * function myPIHander(& $parser,$target, $data){}
-    * </pre>
-    * @param string name of method
-    * @access public
-    * @return void
-    * @see set_object
+     * Sets the processing instruction handler method e.g. for PHP open
+     * and close tags
+     * The handler method must accept three arguments; the parser, the
+     * PI target and data inside the PI
+     * <pre>
+     * function myPIHander(& $parser,$target, $data){}
+     * </pre>
+     * @param string $pi_method Name of method
+     * @access public
+     * @return void
+     * @see set_object()
     */
-    function set_pi_handler($pi_method) {
+    function set_pi_handler($pi_method)
+    {
         $this->state_parser->handler_object_pi = $this->state_parser->handler_default;
         $this->state_parser->handler_method_pi = $pi_method;
     }
 
     /**
-    * Sets the XML escape handler method e.g. for comments and doctype
-    * declarations<br />
-    * The handler method must accept two arguments; the parser and the
-    * contents of the escaped section
-    * <pre>
-    * function myEscapeHander(& $parser, $data){}
-    * </pre>
-    * @param string name of method
-    * @access public
-    * @return void
-    * @see set_object
-    */
-    function set_escape_handler($escape_method) {
+     * Sets the XML escape handler method e.g. for comments and doctype
+     * declarations
+     * The handler method must accept two arguments; the parser and the
+     * contents of the escaped section
+     * <pre>
+     * function myEscapeHander(& $parser, $data){}
+     * </pre>
+     * @param string $escape_method Name of method
+     * @access public
+     * @return void
+     * @see set_object()
+     */
+    function set_escape_handler($escape_method)
+    {
         $this->state_parser->handler_object_escape = $this->state_parser->handler_default;
         $this->state_parser->handler_method_escape = $escape_method;
     }
 
     /**
-    * Sets the JSP/ASP markup handler<br />
-    * The handler method must accept two arguments; the parser and
-    * body of the JASP tag
-    * <pre>
-    * function myJaspHander(& $parser, $data){}
-    * </pre>
-    * @param string name of method
-    * @access public
-    * @return void
-    * @see set_object
+     * Sets the JSP/ASP markup handler
+     * The handler method must accept two arguments; the parser and
+     * body of the JASP tag
+     * <pre>
+     * function myJaspHander(& $parser, $data){}
+     * </pre>
+     * @param string $jasp_method Name of method
+     * @access public
+     * @return void
+     * @see set_object()
     */
-    function set_jasp_handler ($jasp_method) {
+    function set_jasp_handler ($jasp_method)
+    {
         $this->state_parser->handler_object_jasp = $this->state_parser->handler_default;
         $this->state_parser->handler_method_jasp = $jasp_method;
     }
 
     /**
-    * Returns the current string position of the "cursor" inside the XML
-    * document
-    * <br />Intended for use from within a user defined handler called
-    * via the $parser reference e.g.
-    * <pre>
-    * function myDataHandler(& $parser,$data) {
-    *     echo( 'Current position: '.$parser->get_current_position() );
-    * }
-    * </pre>
-    * @access public
-    * @return int
-    * @see get_length
-    */
-    function get_current_position() {
+     * Returns the current string position of the "cursor" inside the XML document
+     * Intended for use from within a user defined handler called
+     * via the $parser reference e.g.
+     * <pre>
+     * function myDataHandler(& $parser,$data) {
+     *     echo( 'Current position: '.$parser->get_current_position() );
+     * }
+     * </pre>
+     * @access public
+     * @return int
+     * @see get_length()
+     */
+    function get_current_position()
+    {
         return $this->state_parser->position;
     }
 
     /**
-    * Returns the string length of the XML document being parsed
-    * @access public
-    * @return int
-    */
-    function get_length() {
+     * Returns the string length of the XML document being parsed
+     * @access public
+     * @return int
+     */
+    function get_length()
+    {
         return $this->state_parser->length;
     }
 
     /**
-    * Start parsing some XML
-    * @param string XML document
-    * @access public
-    * @return void
-    */
-    function parse($data) {
+     * Start parsing some XML
+     * @param string $data XML document
+     * @access public
+     * @return void
+     */
+    function parse($data)
+    {
         $this->state_parser->parse($data);
     }
 }

--- a/XML/HTMLSax3/Decorators.php
+++ b/XML/HTMLSax3/Decorators.php
@@ -22,234 +22,263 @@
 // $Id: Decorators.php,v 1.2 2007/10/29 21:41:35 hfuecks Exp $
 //
 /**
-* Decorators for dealing with parser options
-* @package XML_HTMLSax3
-* @version $Id: Decorators.php,v 1.2 2007/10/29 21:41:35 hfuecks Exp $
-* @see XML_HTMLSax3::set_option
-*/
+ * Decorators for dealing with parser options
+ * @package XML_HTMLSax3
+ * @version $Id: Decorators.php,v 1.2 2007/10/29 21:41:35 hfuecks Exp $
+ * @see XML_HTMLSax3::set_option()
+ */
 /**
-* Trims the contents of element data from whitespace at start and end
-* @package XML_HTMLSax3
-* @access protected
-*/
-class XML_HTMLSax3_Trim {
+ * Trims the contents of element data from whitespace at start and end
+ * @package XML_HTMLSax3
+ * @access protected
+ */
+class XML_HTMLSax3_Trim
+{
     /**
-    * Original handler object
-    * @var object
-    * @access private
-    */
+     * Original handler object
+     * @var object
+     * @access private
+     */
     var $orig_obj;
     /**
-    * Original handler method
-    * @var string
-    * @access private
-    */
+     * Original handler method
+     * @var string
+     * @access private
+     */
     var $orig_method;
+
     /**
-    * Constructs XML_HTMLSax3_Trim
-    * @param object handler object being decorated
-    * @param string original handler method
-    * @access protected
+     * Constructs XML_HTMLSax3_Trim
+     * @param object $orig_obj Handler object being decorated
+     * @param string $orig_method Original handler method
+     * @access protected
     */
     public function __construct($orig_obj, $orig_method)
     {
         $this->orig_obj = $orig_obj;
         $this->orig_method = $orig_method;
     }
+
     /**
-    * Trims the data
-    * @param XML_HTMLSax3
-    * @param string element data
-    * @access protected
-    */
-    function trimData($parser, $data) {
+     * Trims the data
+     * @param XML_HTMLSax3 $parser
+     * @param string $data Element data
+     * @access protected
+     * @return void
+     */
+    function trimData($parser, $data)
+    {
         $data = trim($data);
         if ($data != '') {
             $this->orig_obj->{$this->orig_method}($parser, $data);
         }
     }
 }
+
 /**
-* Coverts tag names to upper case
-* @package XML_HTMLSax3
-* @access protected
-*/
-class XML_HTMLSax3_CaseFolding {
+ * Converts tag names to upper case
+ * @package XML_HTMLSax3
+ * @access protected
+ */
+class XML_HTMLSax3_CaseFolding
+{
     /**
-    * Original handler object
-    * @var object
-    * @access private
-    */
+     * Original handler object
+     * @var object
+     * @access private
+     */
     var $orig_obj;
     /**
-    * Original open handler method
-    * @var string
-    * @access private
-    */
+     * Original open handler method
+     * @var string
+     * @access private
+     */
     var $orig_open_method;
     /**
-    * Original close handler method
-    * @var string
-    * @access private
-    */
+     * Original close handler method
+     * @var string
+     * @access private
+     */
     var $orig_close_method;
+
     /**
-    * Constructs XML_HTMLSax3_CaseFolding
-    * @param object handler object being decorated
-    * @param string original open handler method
-    * @param string original close handler method
-    * @access protected
-    */
+     * Constructs XML_HTMLSax3_CaseFolding
+     * @param object $orig_obj Handler object being decorated
+     * @param string $orig_open_method Original open handler method
+     * @param string $orig_close_method Original close handler method
+     * @access protected
+     */
     public function __construct($orig_obj, $orig_open_method, $orig_close_method)
     {
         $this->orig_obj = $orig_obj;
         $this->orig_open_method = $orig_open_method;
         $this->orig_close_method = $orig_close_method;
     }
+
     /**
-    * Folds up open tag callbacks
-    * @param XML_HTMLSax3
-    * @param string tag name
-    * @param array tag attributes
-    * @access protected
-    */
-    function foldOpen($parser, $tag, $attrs=array(), $empty = FALSE) {
+     * Folds up open tag callbacks
+     * @param XML_HTMLSax3 $parser
+     * @param string $tag Tag name
+     * @param array $attrs Tag attributes
+     * @param bool $empty
+     * @access protected
+     */
+    function foldOpen($parser, $tag, $attrs = array(), $empty = false)
+    {
         $this->orig_obj->{$this->orig_open_method}($parser, strtoupper($tag), $attrs, $empty);
     }
+
     /**
-    * Folds up close tag callbacks
-    * @param XML_HTMLSax3
-    * @param string tag name
-    * @access protected
-    */
-    function foldClose($parser, $tag, $empty = FALSE) {
+     * Folds up close tag callbacks
+     * @param XML_HTMLSax3 $parser
+     * @param string $tag Tag name
+     * @param bool $empty
+     * @access protected
+     */
+    function foldClose($parser, $tag, $empty = false)
+    {
         $this->orig_obj->{$this->orig_close_method}($parser, strtoupper($tag), $empty);
     }
 }
+
 /**
-* Breaks up data by linefeed characters, resulting in additional
-* calls to the data handler
-* @package XML_HTMLSax3
-* @access protected
-*/
-class XML_HTMLSax3_Linefeed {
+ * Breaks up data by linefeed characters, resulting in additional
+ * calls to the data handler
+ * @package XML_HTMLSax3
+ * @access protected
+ */
+class XML_HTMLSax3_Linefeed
+{
     /**
-    * Original handler object
-    * @var object
-    * @access private
-    */
+     * Original handler object
+     * @var object
+     * @access private
+     */
     var $orig_obj;
     /**
-    * Original handler method
-    * @var string
-    * @access private
-    */
+     * Original handler method
+     * @var string
+     * @access private
+     */
     var $orig_method;
+
     /**
-    * Constructs XML_HTMLSax3_LineFeed
-    * @param object handler object being decorated
-    * @param string original handler method
-    * @access protected
-    */
+     * Constructs XML_HTMLSax3_LineFeed
+     * @param object $orig_obj Handler object being decorated
+     * @param string $orig_method Original handler method
+     * @access protected
+     */
     public function __construct($orig_obj, $orig_method)
     {
         $this->orig_obj = $orig_obj;
         $this->orig_method = $orig_method;
     }
+
     /**
-    * Breaks the data up by linefeeds
-    * @param XML_HTMLSax3
-    * @param string element data
-    * @access protected
-    */
-    function breakData($parser, $data) {
+     * Breaks the data up by linefeeds
+     * @param XML_HTMLSax3 $parser
+     * @param string $data Element data
+     * @access protected
+     */
+    function breakData($parser, $data)
+    {
         $data = explode("\n",$data);
         foreach ( $data as $chunk ) {
             $this->orig_obj->{$this->orig_method}($parser, $chunk);
         }
     }
 }
+
 /**
-* Breaks up data by tab characters, resulting in additional
-* calls to the data handler
-* @package XML_HTMLSax3
-* @access protected
-*/
-class XML_HTMLSax3_Tab {
+ * Breaks up data by tab characters, resulting in additional
+ * calls to the data handler
+ * @package XML_HTMLSax3
+ * @access protected
+ */
+class XML_HTMLSax3_Tab
+{
     /**
-    * Original handler object
-    * @var object
-    * @access private
-    */
+     * Original handler object
+     * @var object
+     * @access private
+     */
     var $orig_obj;
     /**
-    * Original handler method
-    * @var string
-    * @access private
-    */
+     * Original handler method
+     * @var string
+     * @access private
+     */
     var $orig_method;
+
     /**
-    * Constructs XML_HTMLSax3_Tab
-    * @param object handler object being decorated
-    * @param string original handler method
-    * @access protected
-    */
+     * Constructs XML_HTMLSax3_Tab
+     * @param object $orig_obj Handler object being decorated
+     * @param string $orig_method Original handler method
+     * @access protected
+     */
     public function __construct($orig_obj, $orig_method)
     {
         $this->orig_obj = $orig_obj;
         $this->orig_method = $orig_method;
     }
+
     /**
-    * Breaks the data up by linefeeds
-    * @param XML_HTMLSax3
-    * @param string element data
-    * @access protected
-    */
-    function breakData($parser, $data) {
+     * Breaks the data up by linefeeds
+     * @param XML_HTMLSax3 $parser
+     * @param string $data Element data
+     * @access protected
+     */
+    function breakData($parser, $data)
+    {
         $data = explode("\t",$data);
         foreach ( $data as $chunk ) {
             $this->orig_obj->{$this->orig_method}($this, $chunk);
         }
     }
 }
+
 /**
-* Breaks up data by XML entities and parses them with html_entity_decode(),
-* resulting in additional calls to the data handler<br />
-* Requires PHP 4.3.0+
-* @package XML_HTMLSax3
-* @access protected
-*/
-class XML_HTMLSax3_Entities_Parsed {
+ * Breaks up data by XML entities and parses them with html_entity_decode(),
+ * resulting in additional calls to the data handler
+ * Requires PHP 4.3.0+
+ * @package XML_HTMLSax3
+ * @access protected
+ */
+class XML_HTMLSax3_Entities_Parsed
+{
     /**
-    * Original handler object
-    * @var object
-    * @access private
-    */
+     * Original handler object
+     * @var object
+     * @access private
+     */
     var $orig_obj;
     /**
-    * Original handler method
-    * @var string
-    * @access private
-    */
+     * Original handler method
+     * @var string
+     * @access private
+     */
     var $orig_method;
+
     /**
-    * Constructs XML_HTMLSax3_Entities_Parsed
-    * @param object handler object being decorated
-    * @param string original handler method
-    * @access protected
-    */
+     * Constructs XML_HTMLSax3_Entities_Parsed
+     * @param object $orig_obj Handler object being decorated
+     * @param string $orig_method Original handler method
+     * @access protected
+     */
     public function __construct($orig_obj, $orig_method)
     {
         $this->orig_obj = $orig_obj;
         $this->orig_method = $orig_method;
     }
+
     /**
-    * Breaks the data up by XML entities
-    * @param XML_HTMLSax3
-    * @param string element data
-    * @access protected
-    */
-    function breakData($parser, $data) {
+     * Breaks the data up by XML entities
+     * @param XML_HTMLSax3 $parser
+     * @param string $data Element data
+     * @access protected
+     */
+    function breakData($parser, $data)
+    {
         $data = preg_split('/(&.+?;)/',$data,-1,PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         foreach ( $data as $chunk ) {
             $chunk = html_entity_decode($chunk,ENT_NOQUOTES);
@@ -257,52 +286,58 @@ class XML_HTMLSax3_Entities_Parsed {
         }
     }
 }
+
 /**
-* Compatibility with older PHP versions
-*/
+ * Compatibility with older PHP versions
+ */
 if (version_compare(phpversion(), '4.3', '<') && !function_exists('html_entity_decode') ) {
     function html_entity_decode($str, $style=ENT_NOQUOTES) {
         return strtr($str,
             array_flip(get_html_translation_table(HTML_ENTITIES,$style)));
     }
 }
+
 /**
-* Breaks up data by XML entities but leaves them unparsed,
-* resulting in additional calls to the data handler<br />
-* @package XML_HTMLSax3
-* @access protected
-*/
-class XML_HTMLSax3_Entities_Unparsed {
+ * Breaks up data by XML entities but leaves them unparsed,
+ * resulting in additional calls to the data handler
+ * @package XML_HTMLSax3
+ * @access protected
+ */
+class XML_HTMLSax3_Entities_Unparsed
+{
     /**
-    * Original handler object
-    * @var object
-    * @access private
-    */
+     * Original handler object
+     * @var object
+     * @access private
+     */
     var $orig_obj;
     /**
-    * Original handler method
-    * @var string
-    * @access private
-    */
+     * Original handler method
+     * @var string
+     * @access private
+     */
     var $orig_method;
+
     /**
-    * Constructs XML_HTMLSax3_Entities_Unparsed
-    * @param object handler object being decorated
-    * @param string original handler method
-    * @access protected
-    */
+     * Constructs XML_HTMLSax3_Entities_Unparsed
+     * @param object $orig_obj Handler object being decorated
+     * @param string $orig_method Original handler method
+     * @access protected
+     */
     public function __construct($orig_obj, $orig_method)
     {
         $this->orig_obj = $orig_obj;
         $this->orig_method = $orig_method;
     }
+
     /**
-    * Breaks the data up by XML entities
-    * @param XML_HTMLSax3
-    * @param string element data
-    * @access protected
-    */
-    function breakData($parser, $data) {
+     * Breaks the data up by XML entities
+     * @param XML_HTMLSax3 $parser
+     * @param string $data Element data
+     * @access protected
+     */
+    function breakData($parser, $data)
+    {
         $data = preg_split('/(&.+?;)/',$data,-1,PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         foreach ( $data as $chunk ) {
             $this->orig_obj->{$this->orig_method}($this, $chunk);
@@ -311,42 +346,46 @@ class XML_HTMLSax3_Entities_Unparsed {
 }
 
 /**
-* Strips the HTML comment markers or CDATA sections from an escape.
-* If XML_OPTIONS_FULL_ESCAPES is on, this decorator is not used.<br />
-* @package XML_HTMLSax3
-* @access protected
-*/
-class XML_HTMLSax3_Escape_Stripper {
+ * Strips the HTML comment markers or CDATA sections from an escape.
+ * If XML_OPTIONS_FULL_ESCAPES is on, this decorator is not used.
+ * @package XML_HTMLSax3
+ * @access protected
+ */
+class XML_HTMLSax3_Escape_Stripper
+{
     /**
-    * Original handler object
-    * @var object
-    * @access private
-    */
+     * Original handler object
+     * @var object
+     * @access private
+     */
     var $orig_obj;
     /**
-    * Original handler method
-    * @var string
-    * @access private
-    */
+     * Original handler method
+     * @var string
+     * @access private
+     */
     var $orig_method;
+
     /**
-    * Constructs XML_HTMLSax3_Entities_Unparsed
-    * @param object handler object being decorated
-    * @param string original handler method
-    * @access protected
-    */
+     * Constructs XML_HTMLSax3_Entities_Unparsed
+     * @param object $orig_obj Handler object being decorated
+     * @param string $orig_method Original handler method
+     * @access protected
+     */
     public function __construct($orig_obj, $orig_method)
     {
         $this->orig_obj = $orig_obj;
         $this->orig_method = $orig_method;
     }
+
     /**
-    * Breaks the data up by XML entities
-    * @param XML_HTMLSax3
-    * @param string element data
-    * @access protected
-    */
-    function strip($parser, $data) {
+     * Breaks the data up by XML entities
+     * @param XML_HTMLSax3 $parser
+     * @param string $data Element data
+     * @access protected
+     */
+    function strip($parser, $data)
+    {
         // Check for HTML comments first
         if ( substr($data,0,2) == '--' ) {
             $patterns = array(

--- a/XML/HTMLSax3/Decorators.php
+++ b/XML/HTMLSax3/Decorators.php
@@ -240,7 +240,6 @@ class XML_HTMLSax3_Tab
 /**
  * Breaks up data by XML entities and parses them with html_entity_decode(),
  * resulting in additional calls to the data handler
- * Requires PHP 4.3.0+
  * @package XML_HTMLSax3
  * @access protected
  */
@@ -284,16 +283,6 @@ class XML_HTMLSax3_Entities_Parsed
             $chunk = html_entity_decode($chunk,ENT_NOQUOTES);
             $this->orig_obj->{$this->orig_method}($this, $chunk);
         }
-    }
-}
-
-/**
- * Compatibility with older PHP versions
- */
-if (version_compare(phpversion(), '4.3', '<') && !function_exists('html_entity_decode') ) {
-    function html_entity_decode($str, $style=ENT_NOQUOTES) {
-        return strtr($str,
-            array_flip(get_html_translation_table(HTML_ENTITIES,$style)));
     }
 }
 

--- a/XML/HTMLSax3/States.php
+++ b/XML/HTMLSax3/States.php
@@ -37,18 +37,21 @@ define('XML_HTMLSAX3_STATE_CLOSING_TAG', 4);
 define('XML_HTMLSAX3_STATE_ESCAPE', 6);
 define('XML_HTMLSAX3_STATE_JASP', 7);
 define('XML_HTMLSAX3_STATE_PI', 8);
+
 /**
-* StartingState searches for the start of any XML tag
-* @package XML_HTMLSax3
-* @access protected
-*/
-class XML_HTMLSax3_StartingState  {
+ * StartingState searches for the start of any XML tag
+ * @package XML_HTMLSax3
+ * @access protected
+ */
+class XML_HTMLSax3_StartingState
+{
     /**
-    * @param XML_HTMLSax3_StateParser subclass
-    * @return constant XML_HTMLSAX3_STATE_TAG
-    * @access protected
-    */
-    function parse($context) {
+     * @param XML_HTMLSax3_StateParser $context Subclass of XML_HTMLSax3_StateParser
+     * @return int Constant XML_HTMLSAX3_STATE_TAG
+     * @access protected
+     */
+    function parse($context)
+    {
         $data = $context->scanUntilString('<');
         if ($data != '') {
             $context->handler_object_data->
@@ -58,18 +61,21 @@ class XML_HTMLSax3_StartingState  {
         return XML_HTMLSAX3_STATE_TAG;
     }
 }
+
 /**
-* Decides which state to move one from after StartingState
-* @package XML_HTMLSax3
-* @access protected
-*/
-class XML_HTMLSax3_TagState {
+ * Decides which state to move one from after StartingState
+ * @package XML_HTMLSax3
+ * @access protected
+ */
+class XML_HTMLSax3_TagState
+{
     /**
-    * @param XML_HTMLSax3_StateParser subclass
-    * @return constant the next state to move into
-    * @access protected
-    */
-    function parse($context) {
+     * @param XML_HTMLSax3_StateParser $context Subclass of XML_HTMLSax3_StateParser
+     * @return int The next state to move into
+     * @access protected
+     */
+    function parse($context)
+    {
         switch($context->ScanCharacter()) {
         case '/':
             return XML_HTMLSAX3_STATE_CLOSING_TAG;
@@ -89,17 +95,19 @@ class XML_HTMLSax3_TagState {
         }
     }
 }
+
 /**
-* Dealing with closing XML tags
-* @package XML_HTMLSax3
-* @access protected
-*/
-class XML_HTMLSax3_ClosingTagState {
+ * Dealing with closing XML tags
+ * @package XML_HTMLSax3
+ * @access protected
+ */
+class XML_HTMLSax3_ClosingTagState
+{
     /**
-    * @param XML_HTMLSax3_StateParser subclass
-    * @return constant XML_HTMLSAX3_STATE_START
-    * @access protected
-    */
+     * @param XML_HTMLSax3_StateParser $context Subclass of XML_HTMLSax3_StateParser
+     * @return int Constant XML_HTMLSAX3_STATE_START
+     * @access protected
+     */
     function parse($context) {
         $tag = $context->scanUntilCharacters('/>');
         if ($tag != '') {
@@ -116,21 +124,23 @@ class XML_HTMLSax3_ClosingTagState {
         return XML_HTMLSAX3_STATE_START;
     }
 }
+
 /**
-* Dealing with opening XML tags
-* @package XML_HTMLSax3
-* @access protected
-*/
-class XML_HTMLSax3_OpeningTagState {
+ * Dealing with opening XML tags
+ * @package XML_HTMLSax3
+ * @access protected
+ */
+class XML_HTMLSax3_OpeningTagState
+{
     /**
-    * Handles attributes
-    * @param string attribute name
-    * @param string attribute value
-    * @return void
-    * @access protected
-    * @see XML_HTMLSax3_AttributeStartState
-    */
-    function parseAttributes($context) {
+     * Handles attributes
+     * @param XML_HTMLSax3_StateParser $context Subclass of XML_HTMLSax3_StateParser
+     * @return array
+     * @access protected
+     * @see XML_HTMLSax3_AttributeStartState
+     */
+    function parseAttributes($context)
+    {
         $Attributes = array();
 
         $context->ignoreWhitespace();
@@ -166,11 +176,12 @@ class XML_HTMLSax3_OpeningTagState {
     }
 
     /**
-    * @param XML_HTMLSax3_StateParser subclass
-    * @return constant XML_HTMLSAX3_STATE_START
-    * @access protected
-    */
-    function parse($context) {
+     * @param XML_HTMLSax3_StateParser $context Subclass of XML_HTMLSax3_StateParser
+     * @return int Constant XML_HTMLSAX3_STATE_START
+     * @access protected
+     */
+    function parse($context)
+    {
         $tag = $context->scanUntilCharacters("/> \n\r\t");
         if ($tag != '') {
             $this->attrs = array();
@@ -198,17 +209,19 @@ class XML_HTMLSax3_OpeningTagState {
 }
 
 /**
-* Deals with XML escapes handling comments and CDATA correctly
-* @package XML_HTMLSax3
-* @access protected
-*/
-class XML_HTMLSax3_EscapeState {
+ * Deals with XML escapes handling comments and CDATA correctly
+ * @package XML_HTMLSax3
+ * @access protected
+ */
+class XML_HTMLSax3_EscapeState
+{
     /**
-    * @param XML_HTMLSax3_StateParser subclass
-    * @return constant XML_HTMLSAX3_STATE_START
-    * @access protected
-    */
-    function parse($context) {
+     * @param XML_HTMLSax3_StateParser $context Subclass of XML_HTMLSax3_StateParser
+     * @return int Constant XML_HTMLSAX3_STATE_START
+     * @access protected
+     */
+    function parse($context)
+    {
         $char = $context->ScanCharacter();
         if ($char == '-') {
             $char = $context->ScanCharacter();
@@ -239,18 +252,21 @@ class XML_HTMLSax3_EscapeState {
         return XML_HTMLSAX3_STATE_START;
     }
 }
+
 /**
-* Deals with JASP/ASP markup
-* @package XML_HTMLSax3
-* @access protected
+ * Deals with JASP/ASP markup
+ * @package XML_HTMLSax3
+ * @access protected
 */
-class XML_HTMLSax3_JaspState {
+class XML_HTMLSax3_JaspState
+{
     /**
-    * @param XML_HTMLSax3_StateParser subclass
-    * @return constant XML_HTMLSAX3_STATE_START
-    * @access protected
-    */
-    function parse($context) {
+     * @param XML_HTMLSax3_StateParser $context Subclass of XML_HTMLSax3_StateParser
+     * @return int Constant XML_HTMLSAX3_STATE_START
+     * @access protected
+     */
+    function parse($context)
+    {
         $text = $context->scanUntilString('%>');
         if ($text != '') {
             $context->handler_object_jasp->
@@ -261,18 +277,21 @@ class XML_HTMLSax3_JaspState {
         return XML_HTMLSAX3_STATE_START;
     }
 }
+
 /**
-* Deals with XML processing instructions
-* @package XML_HTMLSax3
-* @access protected
-*/
-class XML_HTMLSax3_PiState {
+ * Deals with XML processing instructions
+ * @package XML_HTMLSax3
+ * @access protected
+ */
+class XML_HTMLSax3_PiState
+{
     /**
-    * @param XML_HTMLSax3_StateParser subclass
-    * @return constant XML_HTMLSAX3_STATE_START
-    * @access protected
-    */
-    function parse($context) {
+     * @param XML_HTMLSax3_StateParser $context Subclass of XML_HTMLSax3_StateParser
+     * @return int Constant XML_HTMLSAX3_STATE_START
+     * @access protected
+     */
+    function parse($context)
+    {
         $target = $context->scanUntilCharacters(" \n\r\t");
         $data = $context->scanUntilString('?>');
         if ($data != '') {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "source": "https://github.com/pear/XML_HTMLSax3"
   },
   "require": {
-    "php": ">=5.0.0"
+    "php": ">=5.3"
   },
   "require-dev": {},
   "suggest": {

--- a/package.xml
+++ b/package.xml
@@ -65,7 +65,7 @@ This package is now dual licensed under PHP license v3.01 and LGPL 3.0</notes>
  <dependencies>
   <required>
    <php>
-    <min>5.0</min>
+    <min>5.3</min>
    </php>
    <pearinstaller>
     <min>1.4.0b1</min>


### PR DESCRIPTION
After the #1 merge, having class XML_HTMLSax3_StateParser and subclass XML_HTMLSax3_StateParser_Gtet430 was useless so I merge the subclass methods in the main class.

I can't test the code compatibility with PHP versione before 5.3 so I drop the support for the older version (5.1 and 5.2).

I also remove some (useless) compatibility code for PHP < 4.3.